### PR TITLE
[RBP-035] 씬 전환 중 데이터 받아오기 실패

### DIFF
--- a/RhythmBeatPlay/Assets/Scenes/GameScene.unity
+++ b/RhythmBeatPlay/Assets/Scenes/GameScene.unity
@@ -340,6 +340,7 @@ MonoBehaviour:
   score_Step: 0
   note_Count: 0
   combo_Count: 0
+  note_spawner: {fileID: 0}
   score_Text: {fileID: 1740959671}
 --- !u!4 &340407890
 Transform:
@@ -370,9 +371,24 @@ MonoBehaviour:
   note_died: 0
   Start_Counter: {fileID: 1342907929}
   musicSelection: 82_BPM_Dubstep
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
   red_fan: {fileID: 1107088613}
   blue_fan: {fileID: 1501320753}
   pauseUI: {fileID: 500465205}
+=======
+=======
+>>>>>>> Stashed changes
+  musicDataName: song1
+  stage_number: 0
+  red_fan: {fileID: 0}
+  blue_fan: {fileID: 0}
+  DataObjectHandled: {fileID: 0}
+  score_manager: {fileID: 0}
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
   is_pause: 0
   is_pause_possible: 0
   note_spawner: {fileID: 1797893498}
@@ -433,7 +449,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8091a2f9bd2ac549a5b79acb2825ac3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
   notecounter: {fileID: 0}
+=======
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
 --- !u!68 &347392459
 EdgeCollider2D:
   m_ObjectHideFlags: 0
@@ -1780,7 +1802,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &1107088614
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2153,7 +2175,14 @@ RectTransform:
   - {fileID: 442362544}
   - {fileID: 1342907928}
   - {fileID: 934438754}
+<<<<<<< Updated upstream
   - {fileID: 500465206}
+=======
+  - {fileID: 1161940965}
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2181,7 +2210,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!60 &1501320754
 PolygonCollider2D:
   m_ObjectHideFlags: 0
@@ -2518,6 +2547,14 @@ MonoBehaviour:
   totalNoteCount: 0
   divCount: 0
   musicTime: 0
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
+=======
+  noteList: []
+>>>>>>> Stashed changes
+=======
+  noteList: []
+>>>>>>> Stashed changes
   obj:
   - {fileID: 2410803603146073159, guid: 842d6a5925ab67c4d9495f254fa48f37, type: 3}
   - {fileID: 6841891503198077080, guid: c3e782c3602113344a8ff2ee22c60618, type: 3}
@@ -2755,90 +2792,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1947737192
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 4517475263288762057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: noteData.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4517475263288762057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: music
-      value: 
-      objectReference: {fileID: 8300000, guid: 038e630703a3962489a6a7887781b92b, type: 3}
-    - target: {fileID: 4517475263288762057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: title
-      value: 82 BPM Dubstep2
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5015462726310797057, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6401282557492731934, guid: e72247ecfc0576143bed03b6a4835cff,
-        type: 3}
-      propertyPath: m_Name
-      value: 82_BPM_Dubstep
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: e72247ecfc0576143bed03b6a4835cff, type: 3}
 --- !u!1 &1959008197
 GameObject:
   m_ObjectHideFlags: 0

--- a/RhythmBeatPlay/Assets/Script/Common/MusicData.cs
+++ b/RhythmBeatPlay/Assets/Script/Common/MusicData.cs
@@ -47,7 +47,15 @@ public class MusicData : MonoBehaviour
     {
         List<string[]> data = new List<string[]>();
 
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
         TextAsset parseData = Resources.Load("Notedatas/song1", typeof(TextAsset)) as TextAsset;
+=======
+        TextAsset parseData = Resources.Load("Resources/" + Game_Manager.instance.musicDataName, typeof(TextAsset)) as TextAsset;
+>>>>>>> Stashed changes
+=======
+        TextAsset parseData = Resources.Load("Resources/" + Game_Manager.instance.musicDataName, typeof(TextAsset)) as TextAsset;
+>>>>>>> Stashed changes
         StringReader sr = new StringReader(parseData.text);
 
         // 먼저 한줄을 읽는다.
@@ -72,6 +80,7 @@ public class MusicData : MonoBehaviour
         Debug.Log("rate" + int.Parse(data[4][0]));
         bpm = (int.Parse(data[2][0]) * int.Parse(data[4][0]));
         noteCount = int.Parse(data[3][0]);
+        Debug.Log(noteCount);
 
         // 음악 설정
         GameObject.Find("note_spawner").GetComponent<BPMcheck>().bpm = bpm;

--- a/RhythmBeatPlay/Assets/Script/GameScene/Game_Manager.cs
+++ b/RhythmBeatPlay/Assets/Script/GameScene/Game_Manager.cs
@@ -7,44 +7,75 @@ public class Game_Manager : MonoBehaviour
     public static Game_Manager instance;
     public int note_died = 0;
     public Text Start_Counter;
+
     public string musicSelection = "82_BPM_Dubstep";
+    public string musicDataName = "song1";
+    public int stage_number = 0;
 
     public GameObject red_fan;
     public GameObject blue_fan;
     public GameObject pauseUI;
+
+    public GameObject DataObjectHandled;
+    public GameObject score_manager;
+
+    public GameObject DataObjectHandled;
+    public GameObject score_manager;
 
     private void Awake()
     {
         instance = this;
         red_fan = GameObject.Find("fan_red");
         blue_fan = GameObject.Find("fan_blue");
+        DataObjectHandled = GameObject.Find("DataObject");
+        stage_number = 0;
+        stage_number = DataObjectHandled.GetComponent<DataObject>().stageNumber;
+        switch (stage_number)
+        {
+            case 0:
+                musicSelection = "82_BPM_Dubstep";
+                musicDataName = "song1";
+                break;
+            case 1:
+                musicSelection = "108_BPM_Rainbow";
+                musicDataName = "song2";
+                break;
+        }
     }
 
     private int temp_count = 0;
 
     private void Update()
     {
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
         if (note_died > GameObject.Find(musicSelection).GetComponent<MusicData>().GetNoteCount())
+=======
+        if (note_died > note_spawner.GetComponent<note_spawning>().totalNoteCount)
+>>>>>>> Stashed changes
+=======
+        if (note_died > note_spawner.GetComponent<note_spawning>().totalNoteCount)
+>>>>>>> Stashed changes
         {
             Debug.Log("Song Ended");
         }
-        // 개발 중에만 사용할 부분이며, 알파 버전에서는 지워져야만 함.
-        if (Input.GetKeyDown(KeyCode.Space))
-        {
-            notemaking_debug();
-        }
     }
 
+<<<<<<< Updated upstream
+=======
     // 디버그용 함수.
     public void notemaking_debug()
     {
-        print(note_died + 6);
+        print(note_died+6);
     }
 
+
+>>>>>>> Stashed changes
     public bool is_pause = false; // 퍼즈 상태인지에 대한 값. 노트 update등에 사용됨.
     public bool is_pause_possible = false; // pause가 가능한 상태인지에 대해 확인해주는 값.
     public GameObject note_spawner;
 
+    
     private void Start()
     {
         this.GetComponent<UI_Manager>().ReturnCount(); // 게임 시작 카운트를 시작.

--- a/RhythmBeatPlay/Assets/Script/GameScene/note_spawning.cs
+++ b/RhythmBeatPlay/Assets/Script/GameScene/note_spawning.cs
@@ -29,28 +29,8 @@ public class note_spawning : MonoBehaviour
     private void Awake()
     {
         num_data_count = 0;
+        Parse();
         //debug();
-    }
-
-    private void SetSongData()
-    {
-        title = data[0][0];
-        artist = data[1][0];
-        bpm = float.Parse(data[2][0]);
-        totalNoteCount = int.Parse(data[3][0]);
-        divCount = int.Parse(data[4][0]);
-        rbpm = bpm * divCount;
-        this.GetComponent<BPMcheck>().bpm = rbpm;
-        this.GetComponent<BPMcheck>().bgMusic = GameObject.Find(title).GetComponent<AudioSource>();
-        musicTime = this.GetComponent<BPMcheck>().bgMusic.clip.length;
-    }
-
-    private void GetNoteData()
-    {
-        for (int i = 6; i < totalNoteCount + 6; i++)
-        {
-            noteData.Add(new note(int.Parse(data[i][0]), int.Parse(data[i][1]), int.Parse(data[i][2])));
-        }
     }
 
     public void debug()
@@ -68,7 +48,7 @@ public class note_spawning : MonoBehaviour
     // 파싱 작업.
     public void Parse()
     {
-        TextAsset parseData = Resources.Load("Notedatas/song2", typeof(TextAsset)) as TextAsset;
+        TextAsset parseData = Resources.Load("Notedatas/" + Game_Manager.instance.musicDataName, typeof(TextAsset)) as TextAsset;
         StringReader sr = new StringReader(parseData.text);
 
         // 먼저 한줄을 읽는다.
@@ -88,10 +68,34 @@ public class note_spawning : MonoBehaviour
             }
             source = sr.ReadLine();    // 한줄 읽는다.
         }
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
         //musicSelection = "82 BPM Dubstep2";
         Debug.Log("여기까진 되던데");
         // noteData = GameObject.Find(Game_Manager.instance.musicSelection).GetComponent<MusicData>().GetNoteData();
         totalNoteCount = GameObject.Find(Game_Manager.instance.musicSelection).GetComponent<MusicData>().GetNoteCount();
+=======
+=======
+>>>>>>> Stashed changes
+
+        title = data[0][0];
+        artist = data[1][0];
+        bpm = float.Parse(data[2][0]);
+        totalNoteCount = int.Parse(data[3][0]);
+        divCount = int.Parse(data[4][0]);
+        rbpm = bpm * divCount;
+        this.GetComponent<BPMcheck>().bpm = rbpm;
+        this.GetComponent<BPMcheck>().bgMusic = GameObject.Find(title).GetComponent<AudioSource>();
+        musicTime = this.GetComponent<BPMcheck>().bgMusic.clip.length;
+
+        for (int i = 6; i < totalNoteCount + 6; i++)
+        {
+            noteData.Add(new note(int.Parse(data[i][0]), int.Parse(data[i][1]), int.Parse(data[i][2])));
+        }
+<<<<<<< Updated upstream
+>>>>>>> Stashed changes
+=======
+>>>>>>> Stashed changes
     }
 
     public void noteSpawn(int _beatcount)
@@ -107,7 +111,7 @@ public class note_spawning : MonoBehaviour
         }
     }
 
-    public class note
+    /*public class note
     {
         private int bar; // bpm의 마디를 의미.
         private int degree; // 각도
@@ -157,5 +161,13 @@ public class note_spawning : MonoBehaviour
             degree = m_degree;
             type = m_type;
         }
+<<<<<<< Updated upstream
+<<<<<<< Updated upstream
     }
+=======
+    }*/
+>>>>>>> Stashed changes
+=======
+    }*/
+>>>>>>> Stashed changes
 }

--- a/RhythmBeatPlay/Assets/Script/GameScene/on_Hit_Note_Edge.cs
+++ b/RhythmBeatPlay/Assets/Script/GameScene/on_Hit_Note_Edge.cs
@@ -12,7 +12,7 @@ public class on_Hit_Note_Edge : MonoBehaviour
     {
         score_Manager = GameObject.Find("ScoreManager");
     }
-    public Text notecounter;
+    //public Text notecounter;
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
@@ -21,7 +21,7 @@ public class on_Hit_Note_Edge : MonoBehaviour
             Destroy(collision.gameObject);
             score_Manager.GetComponent<score_Manager>().Increase_Score(true, 0);
             Game_Manager.instance.note_died++;
-            notecounter.text = (Game_Manager.instance.note_died + 6).ToString();
+            //notecounter.text = (Game_Manager.instance.note_died + 6).ToString();
         }
     }
 }

--- a/RhythmBeatPlay/Assets/Script/GameScene/on_Hit_Note_RB.cs
+++ b/RhythmBeatPlay/Assets/Script/GameScene/on_Hit_Note_RB.cs
@@ -11,6 +11,7 @@ public class on_Hit_Note_RB : MonoBehaviour
     GameObject blue_Fan;
     GameObject red_Fan;
 
+
     private float degree_Difference;
 
     enum Grade
@@ -48,7 +49,6 @@ public class on_Hit_Note_RB : MonoBehaviour
 
     private void Calculate_Score() // Sending judeged note_degrees.
     {
-        
         Debug.Log(Mathf.Rad2Deg * degree_Difference);
         // Is_Purple에서 보라색이 아니므로 0, 단계에 맞는 Increase_score grade를 주면 된다.
         if (degree_Difference >= 8.0) // Bad

--- a/RhythmBeatPlay/Assets/Script/GameScene/score_Manager.cs
+++ b/RhythmBeatPlay/Assets/Script/GameScene/score_Manager.cs
@@ -9,15 +9,21 @@ public class score_Manager : MonoBehaviour
 
     public int combo_Count; // 콤보 카운터
 
-
+    public GameObject note_spawner;
     public Text score_Text; // 점수 텍스트 제작.
+
+    private void Awake()
+    {
+        note_spawner = GameObject.Find("note_spawner");
+    }
 
     // Start is called before the first frame update
     private void Start()
     {
         score = 0;
         combo_Count = 0;
-        note_Count = GameObject.Find(Game_Manager.instance.musicSelection).GetComponent<MusicData>().GetNoteCount();
+        //note_Count = GameObject.Find(Game_Manager.instance.musicSelection).GetComponent<MusicData>().GetNoteCount();
+        note_Count = note_spawner.GetComponent<note_spawning>().totalNoteCount;
         score_Step = 1000000 / note_Count;
     }
 


### PR DESCRIPTION
- 스테이지 씬에서 MusicData의 상태로 넘어오지 않고, DataObject라는 이름의 오브젝트 1개만 넘어오는것이 문제였음.
- 그렇기에 DataObject의 데이터값을 받아 게임 씬 시작 이전에 노트 / 곡 데이터를 바꾸도록 설정.
- MusicData의 적용은 아마 스테이지 담당자에게 부탁해봐야 할듯.