### PR TITLE
[RBP-039] MusicSelectScene-GameScene 연동

### DIFF
--- a/RhythmBeatPlay/Assets/Script/Common/MusicInfo.cs
+++ b/RhythmBeatPlay/Assets/Script/Common/MusicInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MusicInfo : MonoBehaviour
+{
+    [SerializeField]
+    AudioClip music;
+
+    [SerializeField]
+    string title;
+
+    [SerializeField]
+    string artist;
+
+    [SerializeField]
+    string album;
+
+    [SerializeField]
+    int noteCount;
+
+    [SerializeField]
+    int bpm;
+
+    [SerializeField]
+    float musicLengthSecond;
+
+    // must be scaled 1:1
+    [SerializeField]
+    Sprite titleSprite;
+
+    // must be scaled 16:9
+    [SerializeField]
+    Sprite backgroundSprite;
+}

--- a/RhythmBeatPlay/Assets/Script/Common/MusicInfo.cs.meta
+++ b/RhythmBeatPlay/Assets/Script/Common/MusicInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4f74285ad0544c42892930151665e5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RhythmBeatPlay/Assets/Script/Common/MusicInfoManager.cs
+++ b/RhythmBeatPlay/Assets/Script/Common/MusicInfoManager.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class MusicInfoManager
+{
+    public static MusicInfo GetMusicInfo(string code)
+    {
+        return Resources.Load<MusicInfo>($"Prefabs/MusicPrefabs/{code}");
+    }
+    public static MusicInfo GetMusicInfo(int code)
+    {
+        return GetMusicInfo(code.ToString("0000"));
+    }
+    public static MusicInfo GetMusicInfo(int stagenum, int musicnum)
+    {
+        return GetMusicInfo(stagenum * 100 + musicnum);
+    }
+}

--- a/RhythmBeatPlay/Assets/Script/Common/MusicInfoManager.cs.meta
+++ b/RhythmBeatPlay/Assets/Script/Common/MusicInfoManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c80a99b1b2852a40b71b7aafedc58ef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/RhythmBeatPlay/ProjectSettings/EditorBuildSettings.asset
+++ b/RhythmBeatPlay/ProjectSettings/EditorBuildSettings.asset
@@ -23,4 +23,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/GameScene.unity
     guid: e270e7e369186f34a93c3e81141f22d9
+  - enabled: 1
+    path: Assets/Scenes/ResultScene.unity
+    guid: 32c7e23d5fd713f4080b5f6afaa3992f
   m_configObjects: {}


### PR DESCRIPTION
- https://trello.com/c/FMxcUskj/310-rbp-039-musicselectscene-gamescene-%EC%97%B0%EB%8F%99
- 오디오클립, 제목, 아티스트, 앨범, noteCount, bpm, musicLengthSecond, titleSprite, backgroundSprite 로 구성된 MusicInfo 스크립트
- MusicInfo 스크립트가 부착된 Music Prefab
- MusicInfoManager를 통해 music code 또는 스테이지와 음악 순서번호로 MusicInfo load
- 게임씬에서 stage와 music 순서번호 확인은 DataManager의 stageNumber, musicNumber